### PR TITLE
Catch case when no task in cluster

### DIFF
--- a/scripts/preview/utils/ecs.ts
+++ b/scripts/preview/utils/ecs.ts
@@ -151,10 +151,15 @@ async function getRunningTask(slug: string): Promise<AWS.ECS.Task | undefined> {
     desiredStatus: 'RUNNING',
   };
 
-  const tasks = await Clients.ecs.listTasks(params).promise();
+  const tasks: any = await Clients.ecs.listTasks(params).promise();
 
   if (!tasks.taskArns) {
     throw new Error('[getRunningTask]: tasks arns does not exist');
+  }
+
+  if(tasks.taskArns?.length === 0 ) {
+    log.info(`No running task found for: ${slug}`);
+    return undefined;
   }
 
   const allTasks = await getTasksDetails(tasks.taskArns);

--- a/scripts/preview/utils/ecs.ts
+++ b/scripts/preview/utils/ecs.ts
@@ -151,7 +151,7 @@ async function getRunningTask(slug: string): Promise<AWS.ECS.Task | undefined> {
     desiredStatus: 'RUNNING',
   };
 
-  const tasks: any = await Clients.ecs.listTasks(params).promise();
+  const tasks: AWS.ECS.ListTasksResponse = await Clients.ecs.listTasks(params).promise();
 
   if (!tasks.taskArns) {
     throw new Error('[getRunningTask]: tasks arns does not exist');


### PR DESCRIPTION
When it's the first time running the provision it runs `stopTask` to check if there exists any running tasks in the cluster, but since it's the first time, it returns an empty array `taskArns":[]`. Currently fails because the next function `getTasksDetails` will get an empty array and needs at least one task to function properly.